### PR TITLE
Rebase & adding support for MatchGroup in Payload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.x'
+          go-version: '1.20.x'
 
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.20.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.20.x'
 
@@ -32,18 +32,18 @@ jobs:
     needs: [ test ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         
       - name: Unshallow
         run: git fetch --prune --unshallow
         
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.20.x'
           
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.x'
+          go-version: '1.20.x'
 
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.x'
+          go-version: '1.20.x'
           
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ ssosync
 # Noise from os/editors
 .DS_Store
 *.swp
+*/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ ssosync
 .DS_Store
 *.swp
 */.DS_Store
+cicd/.DS_Store
+release.yaml
+staging.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ ssosync
 cicd/.DS_Store
 release.yaml
 staging.yaml
+*.orig
+*.rej

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ release.yaml
 staging.yaml
 *.orig
 *.rej
+
+# Local files
+.env
+event.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,13 +34,13 @@ changelog:
     - Merge pull request
     - Merge branch
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
     format_overrides:
     - goos: windows
       format: zip

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ test:
 go-build:
 	go build -o $(APP_NAME) main.go
 
-build-SSOSyncFunction:
-	GOOS=linux GOARCH=arm64 go build -o bootstrap main.go
-	cp ./bootstrap $(ARTIFACTS_DIR)/.
-
 .PHONY: clean
 clean:
 	rm -f $(OUTPUT) $(PACKAGED_TEMPLATE)
+
+build-SSOSyncFunction:
+	GOOS=linux GOARCH=arm64 go build -o bootstrap main.go
+	cp ./bootstrap $(ARTIFACTS_DIR)/.
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test:
 go-build:
 	go build -o $(APP_NAME) main.go
 
+build-SSOSyncFunction:
+	GOOS=linux GOARCH=arm64 go build -o bootstrap main.go
+	cp ./bootstrap $(ARTIFACTS_DIR)/.
+
 .PHONY: clean
 clean:
 	rm -f $(OUTPUT) $(PACKAGED_TEMPLATE)

--- a/README.md
+++ b/README.md
@@ -171,8 +171,10 @@ NOTES:
 NOTE: Using Lambda may incur costs in your AWS account. Please make sure you have checked
 the pricing for AWS Lambda and CloudWatch before continuing.
 
+Additionally, before choosing to deploy with Lambda, please ensure that the [AWS Lambda SLAs](https://aws.amazon.com/lambda/sla/) are sufficient for your use cases.
+
 Running ssosync once means that any changes to your Google directory will not appear in
-AWS SSO. To sync. regularly, you can run ssosync via AWS Lambda.
+AWS SSO. To sync regularly, you can run ssosync via AWS Lambda.
 
 :warning: You find it in the [AWS Serverless Application Repository](https://eu-west-1.console.aws.amazon.com/lambda/home#/create/app?applicationId=arn:aws:serverlessrepo:us-east-2:004480582608:applications/SSOSync).
 

--- a/cicd/build/build/buildspec.yml
+++ b/cicd/build/build/buildspec.yml
@@ -9,12 +9,7 @@ phases:
   install: 
     commands:
       # Install go.lang
-      - wget -q https://storage.googleapis.com/golang/go${GoVersion}.linux-amd64.tar.gz
-      - rm -rf /go
-      - tar -C / -xzf go${GoVersion}.linux-amd64.tar.gz
-      - export PATH="/go/bin:$PATH" && export GOPATH="/go" && export PATH="$GOPATH/bin:$PATH"
-      - rm go${GoVersion}.linux-amd64.tar.gz
-      - go version
+      - GoVersion=${GOLANG_20_VERSION}
 
       # Install golint
       - go install golang.org/x/lint/golint@latest

--- a/cicd/build/build/buildspec.yml
+++ b/cicd/build/build/buildspec.yml
@@ -63,8 +63,8 @@ phases:
       # Tweak the .goreleaser.yml so it uses the vairables from .Env
       - patch .goreleaser.yml cicd/build/build/goreleaser.patch
 
-      # Make main but only for the lambda (linux amd64)
-      - goreleaser build --snapshot --rm-dist --single-target
+      # Make main 
+      - goreleaser build --snapshot --clean
 
 
       # Check we've packaged something useful
@@ -74,3 +74,4 @@ artifacts:
   files:
     - ${APP_NAME}
     - dist/**/*
+

--- a/cicd/build/build/goreleaser.patch
+++ b/cicd/build/build/goreleaser.patch
@@ -1,8 +1,21 @@
---- .goreleaser.yml	2022-06-15 08:38:24.000000000 +0100
-+++ .goreleaser-codebuild.yml	2022-06-21 12:33:43.000000000 +0100
-@@ -22,7 +22,7 @@
-     - goos: windows
-       goarch: 386
+--- .goreleaser.yml.default	2023-10-25 11:30:58
++++ .goreleaser.yml	2023-10-25 11:32:18
+@@ -9,20 +9,11 @@
+     - CGO_ENABLED=0
+   goos:
+     - linux
+-    - darwin
+-    - windows
+   goarch:
+-    - 386
+     - amd64
+-    - arm
+     - arm64
+-  ignore:
+-    - goos: darwin
+-      goarch: 386
+-    - goos: windows
+-      goarch: 386
    ldflags:
 -     - -s -w -X github.com/awslabs/ssosync/cmd.version={{.Version}} -X github.com/awslabs/ssosync/cmd.commit={{.Commit}} -X github.com/awslabs/ssosync/cmd.date={{.Date}} -X github.com/awslabs/ssosync/cmd.builtBy=goreleaser
 +     - -s -w -X github.com/awslabs/ssosync/cmd.version={{.Env.GitTag}} -X github.com/awslabs/ssosync/cmd.commit={{.Env.GitCommit}} -X github.com/awslabs/ssosync/cmd.date={{.Date}} -X github.com/awslabs/ssosync/cmd.builtBy=goreleaser -X github.com/awslabs/ssosync/cmd.goversion={{.Env.GoVersion}}

--- a/cicd/build/package/buildspec.yml
+++ b/cicd/build/package/buildspec.yml
@@ -14,10 +14,12 @@ phases:
       # Check that the files need to package exist
       - ls README.md
       - ls SAR.md
-      - ls dist/ssosync_linux_amd64_v1/ssosync
+      - ls dist/ssosync_linux_arm64/ssosync
+      - ls dist/ssosync_linux_amd64_v1/ssosync 
  
       # Check that the executable works
       - ./dist/ssosync_linux_amd64_v1/ssosync --version 
+      - mv dist/ssosync_linux_arm64/ssosync bootstrap
 
   build:
     commands:

--- a/cicd/build/package/release.patch
+++ b/cicd/build/package/release.patch
@@ -1,14 +1,5 @@
---- template.yaml	2023-10-27 14:15:25
-+++ release.yaml	2023-10-27 14:41:17
-@@ -11,7 +11,7 @@
-           - SCIMEndpointAccessToken
-           - IdentityStoreId
-       - Label:
--          default: Google Workspace Credentials 
-+          default: Google Workspace Credentials
-         Parameters:
-           - GoogleAdminEmail
-           - GoogleCredentials
+--- template.yaml	2023-10-27 16:02:11
++++ release.yaml	2023-10-27 16:06:09
 @@ -36,7 +36,7 @@
            - ScheduleExpression
  
@@ -18,65 +9,3 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -113,13 +113,11 @@
-     Description: |
-       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
-     Default: '*'
--    AllowedPattern: "(*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))"
-   GoogleGroupMatch:
-     Type: String
-     Description: |
-       Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
-     Default: 'name:AWS*'
--    AllowedPattern: "((name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64})))|((email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260})))"
-   IgnoreGroups:
-     Type: String
-     Description: |
-@@ -132,7 +130,7 @@
-     Default: 'none'
-   IncludeGroups:
-     Type: String
--    Description: |
-+    Description: | 
-       Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
-     Default: '*'
-   SyncMethod:
-@@ -142,16 +140,16 @@
-     AllowedValues:
-       - groups
-       - users_groups
-+      
-+      
-+      
- 
--
--
--
- Resources:
-   SSOSyncFunction:
-     Type: AWS::Serverless::Function
-     Properties:
-       Runtime: provided.al2
--      Handler: dist/ssosync_linux_arm64/ssosync
-+      Handler: bootstrap
-       Architectures:
-         - arm64
-       Timeout: !Ref TimeOut
-@@ -184,8 +182,6 @@
-                 - !Ref AWSSCIMAccessTokenSecret
-                 - !Ref AWSRegionSecret
-                 - !Ref AWSIdentityStoreIDSecret
--        - Version: '2012-10-17'
--          Statement:
-             - Sid: IdentityStoreAccesPolicy
-               Effect: Allow
-               Action:
-@@ -214,8 +210,6 @@
-           Properties:
-             Enabled: true
-             Schedule: !Ref ScheduleExpression
--    Metadata:
--      BuildMethod: makefile
- 
-   AWSGoogleCredentialsSecret:
-     Type: "AWS::SecretsManager::Secret"

--- a/cicd/build/package/release.patch
+++ b/cicd/build/package/release.patch
@@ -1,7 +1,16 @@
---- template.yaml	2023-10-25 09:44:33
-+++ release.yaml	2023-10-25 16:02:21
-@@ -27,7 +27,7 @@
-           - IncludeGroups
+--- template.yaml	2023-10-27 14:15:25
++++ release.yaml	2023-10-27 14:41:17
+@@ -11,7 +11,7 @@
+           - SCIMEndpointAccessToken
+           - IdentityStoreId
+       - Label:
+-          default: Google Workspace Credentials 
++          default: Google Workspace Credentials
+         Parameters:
+           - GoogleAdminEmail
+           - GoogleCredentials
+@@ -36,7 +36,7 @@
+           - ScheduleExpression
  
    AWS::ServerlessRepo::Application:
 -    Name: ssosync
@@ -9,7 +18,21 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -111,7 +111,7 @@
+@@ -113,13 +113,11 @@
+     Description: |
+       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
+     Default: '*'
+-    AllowedPattern: "(*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))"
+   GoogleGroupMatch:
+     Type: String
+     Description: |
+       Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
+     Default: 'name:AWS*'
+-    AllowedPattern: "((name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64})))|((email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260})))"
+   IgnoreGroups:
+     Type: String
+     Description: |
+@@ -132,7 +130,7 @@
      Default: 'none'
    IncludeGroups:
      Type: String
@@ -18,7 +41,7 @@
        Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
      Default: '*'
    SyncMethod:
-@@ -121,16 +121,16 @@
+@@ -142,16 +140,16 @@
      AllowedValues:
        - groups
        - users_groups
@@ -38,8 +61,8 @@
 +      Handler: bootstrap
        Architectures:
          - arm64
-       Timeout: 300
-@@ -163,8 +163,6 @@
+       Timeout: !Ref TimeOut
+@@ -184,8 +182,6 @@
                  - !Ref AWSSCIMAccessTokenSecret
                  - !Ref AWSRegionSecret
                  - !Ref AWSIdentityStoreIDSecret
@@ -48,7 +71,7 @@
              - Sid: IdentityStoreAccesPolicy
                Effect: Allow
                Action:
-@@ -187,8 +185,6 @@
+@@ -214,8 +210,6 @@
            Properties:
              Enabled: true
              Schedule: !Ref ScheduleExpression

--- a/cicd/build/package/release.patch
+++ b/cicd/build/package/release.patch
@@ -1,5 +1,5 @@
---- template.yaml	2022-11-29 16:56:21.000000000 +0000
-+++ release.yaml	2022-11-29 17:11:58.000000000 +0000
+--- template.yaml	2023-10-25 09:44:33
++++ release.yaml	2023-10-25 16:02:21
 @@ -27,7 +27,7 @@
            - IncludeGroups
  
@@ -9,29 +9,37 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -107,7 +107,7 @@
-       Ignore these Google Workspace users
+@@ -111,7 +111,7 @@
+     Default: 'none'
    IncludeGroups:
      Type: String
 -    Description: |
 +    Description: | 
        Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
+     Default: '*'
    SyncMethod:
-     Type: String
-@@ -116,9 +116,9 @@
+@@ -121,16 +121,16 @@
      AllowedValues:
        - groups
        - users_groups
--
--
--
 +      
 +      
 +      
  
+-
+-
+-
  Resources:
    SSOSyncFunction:
-@@ -156,8 +156,6 @@
+     Type: AWS::Serverless::Function
+     Properties:
+       Runtime: provided.al2
+-      Handler: dist/ssosync_linux_arm64/ssosync
++      Handler: bootstrap
+       Architectures:
+         - arm64
+       Timeout: 300
+@@ -163,8 +163,6 @@
                  - !Ref AWSSCIMAccessTokenSecret
                  - !Ref AWSRegionSecret
                  - !Ref AWSIdentityStoreIDSecret
@@ -40,3 +48,12 @@
              - Sid: IdentityStoreAccesPolicy
                Effect: Allow
                Action:
+@@ -187,8 +185,6 @@
+           Properties:
+             Enabled: true
+             Schedule: !Ref ScheduleExpression
+-    Metadata:
+-      BuildMethod: makefile
+ 
+   AWSGoogleCredentialsSecret:
+     Type: "AWS::SecretsManager::Secret"

--- a/cicd/build/package/release.patch
+++ b/cicd/build/package/release.patch
@@ -1,5 +1,5 @@
---- template.yaml	2023-10-27 16:02:11
-+++ release.yaml	2023-10-27 16:06:09
+--- template.yaml	2023-10-27 16:34:16
++++ release.yaml	2023-10-27 16:34:37
 @@ -36,7 +36,7 @@
            - ScheduleExpression
  

--- a/cicd/build/package/staging.patch
+++ b/cicd/build/package/staging.patch
@@ -1,5 +1,5 @@
---- template.yaml	2023-10-27 16:02:11
-+++ staging.yaml	2023-10-27 16:04:04
+--- template.yaml	2023-10-27 16:34:16
++++ staging.yaml	2023-10-27 16:33:15
 @@ -36,7 +36,7 @@
            - ScheduleExpression
  
@@ -9,7 +9,7 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -147,6 +147,7 @@
+@@ -143,6 +143,7 @@
    SSOSyncFunction:
      Type: AWS::Serverless::Function
      Properties:
@@ -17,7 +17,7 @@
        Runtime: provided.al2
        Handler: bootstrap
        Architectures:
-@@ -246,3 +247,10 @@
+@@ -242,3 +243,10 @@
      Properties:
        Name: SSOSyncIdentityStoreID
        SecretString: !Ref IdentityStoreID

--- a/cicd/build/package/staging.patch
+++ b/cicd/build/package/staging.patch
@@ -1,6 +1,6 @@
---- template.yaml	2023-10-27 16:34:16
-+++ staging.yaml	2023-10-27 16:33:15
-@@ -36,7 +36,7 @@
+--- template.yaml	2023-10-30 14:21:20
++++ staging.yaml	2023-10-30 14:21:59
+@@ -38,7 +38,7 @@
            - ScheduleExpression
  
    AWS::ServerlessRepo::Application:
@@ -9,22 +9,3 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -143,6 +143,7 @@
-   SSOSyncFunction:
-     Type: AWS::Serverless::Function
-     Properties:
-+      FunctionName: SSOSyncFunction
-       Runtime: provided.al2
-       Handler: bootstrap
-       Architectures:
-@@ -242,3 +243,10 @@
-     Properties:
-       Name: SSOSyncIdentityStoreID
-       SecretString: !Ref IdentityStoreID
-+
-+Outputs:
-+  FunctionArn:
-+    Description: "The Arn of the deployed lambda function"
-+    Value: !GetAtt SSOSyncFunction.Arn
-+    Export:
-+      Name: SSOSyncFunctionARN

--- a/cicd/build/package/staging.patch
+++ b/cicd/build/package/staging.patch
@@ -1,7 +1,16 @@
---- template.yaml	2023-10-25 09:44:33
-+++ staging.yaml	2023-10-25 16:02:07
-@@ -27,7 +27,7 @@
-           - IncludeGroups
+--- template.yaml	2023-10-27 14:15:25
++++ staging.yaml	2023-10-27 14:15:30
+@@ -11,7 +11,7 @@
+           - SCIMEndpointAccessToken
+           - IdentityStoreId
+       - Label:
+-          default: Google Workspace Credentials 
++          default: Google Workspace Credentials
+         Parameters:
+           - GoogleAdminEmail
+           - GoogleCredentials
+@@ -36,7 +36,7 @@
+           - ScheduleExpression
  
    AWS::ServerlessRepo::Application:
 -    Name: ssosync
@@ -9,7 +18,7 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -111,7 +111,7 @@
+@@ -132,7 +132,7 @@
      Default: 'none'
    IncludeGroups:
      Type: String
@@ -18,7 +27,7 @@
        Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
      Default: '*'
    SyncMethod:
-@@ -121,16 +121,17 @@
+@@ -142,16 +142,17 @@
      AllowedValues:
        - groups
        - users_groups
@@ -39,8 +48,8 @@
 +      Handler: bootstrap
        Architectures:
          - arm64
-       Timeout: 300
-@@ -163,8 +164,6 @@
+       Timeout: !Ref TimeOut
+@@ -184,8 +185,6 @@
                  - !Ref AWSSCIMAccessTokenSecret
                  - !Ref AWSRegionSecret
                  - !Ref AWSIdentityStoreIDSecret
@@ -49,10 +58,10 @@
              - Sid: IdentityStoreAccesPolicy
                Effect: Allow
                Action:
-@@ -180,16 +179,14 @@
-                 - "identitystore:DeleteGroup"
-               Resource:
-                 - "*"
+@@ -207,15 +206,6 @@
+                 - codepipeline:PutJobSuccessResult
+                 - codepipeline:PutJobFailureResult
+               Resource: "*"
 -      Events:
 -        SyncScheduledEvent:
 -          Type: Schedule
@@ -63,20 +72,21 @@
 -    Metadata:
 -      BuildMethod: makefile
  
-+            - Sid: CodePipelinePolicy
-+              Effect: Allow
-+              Action:
-+                - codepipeline:PutJobSuccessResult
-+                - codepipeline:PutJobFailureResult
-+              Resource: "*"
-+
    AWSGoogleCredentialsSecret:
      Type: "AWS::SecretsManager::Secret"
+@@ -245,10 +235,17 @@
+     Type: "AWS::SecretsManager::Secret"
      Properties:
-@@ -225,3 +222,10 @@
+       Name: SSOSyncRegion
+-      SecretString: !Select [1, !Split [".", !Ref SCIMEndpointUrl]]
++      SecretString: !Ref Region
+ 
+   AWSIdentityStoreIDSecret:
+     Type: "AWS::SecretsManager::Secret"
      Properties:
        Name: SSOSyncIdentityStoreID
-       SecretString: !Ref IdentityStoreID
+-      SecretString: !Ref IdentityStoreID
++      SecretString: !Select [1, !Split [".", !Ref SCIMEndpointUrl]]
 +
 +Outputs:
 +  FunctionArn:

--- a/cicd/build/package/staging.patch
+++ b/cicd/build/package/staging.patch
@@ -1,5 +1,5 @@
---- template.yaml	2022-11-29 16:56:21.000000000 +0000
-+++ staging.yaml	2022-11-29 17:10:47.000000000 +0000
+--- template.yaml	2023-10-25 09:44:33
++++ staging.yaml	2023-10-25 16:02:07
 @@ -27,7 +27,7 @@
            - IncludeGroups
  
@@ -9,35 +9,38 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -107,7 +107,7 @@
-       Ignore these Google Workspace users
+@@ -111,7 +111,7 @@
+     Default: 'none'
    IncludeGroups:
      Type: String
 -    Description: |
 +    Description: | 
        Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
+     Default: '*'
    SyncMethod:
-     Type: String
-@@ -116,14 +116,15 @@
+@@ -121,16 +121,17 @@
      AllowedValues:
        - groups
        - users_groups
--
--
--
 +      
 +      
 +      
  
+-
+-
+-
  Resources:
    SSOSyncFunction:
      Type: AWS::Serverless::Function
      Properties:
 +      FunctionName: SSOSyncFunction
-       Runtime: go1.x
-       Handler: dist/ssosync_linux_amd64_v1/ssosync
+       Runtime: provided.al2
+-      Handler: dist/ssosync_linux_arm64/ssosync
++      Handler: bootstrap
+       Architectures:
+         - arm64
        Timeout: 300
-@@ -156,8 +157,6 @@
+@@ -163,8 +164,6 @@
                  - !Ref AWSSCIMAccessTokenSecret
                  - !Ref AWSRegionSecret
                  - !Ref AWSIdentityStoreIDSecret
@@ -46,8 +49,8 @@
              - Sid: IdentityStoreAccesPolicy
                Effect: Allow
                Action:
-@@ -172,13 +171,13 @@
-                 - "identitystore:DeleteGroupMembership"
+@@ -180,16 +179,14 @@
+                 - "identitystore:DeleteGroup"
                Resource:
                  - "*"
 -      Events:
@@ -57,17 +60,20 @@
 -          Properties:
 -            Enabled: true
 -            Schedule: !Ref ScheduleExpression
-+
+-    Metadata:
+-      BuildMethod: makefile
+ 
 +            - Sid: CodePipelinePolicy
 +              Effect: Allow
 +              Action:
 +                - codepipeline:PutJobSuccessResult
 +                - codepipeline:PutJobFailureResult
 +              Resource: "*"
- 
++
    AWSGoogleCredentialsSecret:
      Type: "AWS::SecretsManager::Secret"
-@@ -215,3 +214,10 @@
+     Properties:
+@@ -225,3 +222,10 @@
      Properties:
        Name: SSOSyncIdentityStoreID
        SecretString: !Ref IdentityStoreID

--- a/cicd/build/package/staging.patch
+++ b/cicd/build/package/staging.patch
@@ -1,14 +1,5 @@
---- template.yaml	2023-10-27 14:15:25
-+++ staging.yaml	2023-10-27 14:15:30
-@@ -11,7 +11,7 @@
-           - SCIMEndpointAccessToken
-           - IdentityStoreId
-       - Label:
--          default: Google Workspace Credentials 
-+          default: Google Workspace Credentials
-         Parameters:
-           - GoogleAdminEmail
-           - GoogleCredentials
+--- template.yaml	2023-10-27 16:02:11
++++ staging.yaml	2023-10-27 16:04:04
 @@ -36,7 +36,7 @@
            - ScheduleExpression
  
@@ -18,75 +9,18 @@
      Description: Helping you populate AWS SSO directly with your Google Apps users.
      Author: Sebastian Doell
      SpdxLicenseId: Apache-2.0
-@@ -132,7 +132,7 @@
-     Default: 'none'
-   IncludeGroups:
-     Type: String
--    Description: |
-+    Description: | 
-       Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
-     Default: '*'
-   SyncMethod:
-@@ -142,16 +142,17 @@
-     AllowedValues:
-       - groups
-       - users_groups
-+      
-+      
-+      
- 
--
--
--
- Resources:
+@@ -147,6 +147,7 @@
    SSOSyncFunction:
      Type: AWS::Serverless::Function
      Properties:
 +      FunctionName: SSOSyncFunction
        Runtime: provided.al2
--      Handler: dist/ssosync_linux_arm64/ssosync
-+      Handler: bootstrap
+       Handler: bootstrap
        Architectures:
-         - arm64
-       Timeout: !Ref TimeOut
-@@ -184,8 +185,6 @@
-                 - !Ref AWSSCIMAccessTokenSecret
-                 - !Ref AWSRegionSecret
-                 - !Ref AWSIdentityStoreIDSecret
--        - Version: '2012-10-17'
--          Statement:
-             - Sid: IdentityStoreAccesPolicy
-               Effect: Allow
-               Action:
-@@ -207,15 +206,6 @@
-                 - codepipeline:PutJobSuccessResult
-                 - codepipeline:PutJobFailureResult
-               Resource: "*"
--      Events:
--        SyncScheduledEvent:
--          Type: Schedule
--          Name: AWSSyncSchedule
--          Properties:
--            Enabled: true
--            Schedule: !Ref ScheduleExpression
--    Metadata:
--      BuildMethod: makefile
- 
-   AWSGoogleCredentialsSecret:
-     Type: "AWS::SecretsManager::Secret"
-@@ -245,10 +235,17 @@
-     Type: "AWS::SecretsManager::Secret"
-     Properties:
-       Name: SSOSyncRegion
--      SecretString: !Select [1, !Split [".", !Ref SCIMEndpointUrl]]
-+      SecretString: !Ref Region
- 
-   AWSIdentityStoreIDSecret:
-     Type: "AWS::SecretsManager::Secret"
+@@ -246,3 +247,10 @@
      Properties:
        Name: SSOSyncIdentityStoreID
--      SecretString: !Ref IdentityStoreID
-+      SecretString: !Select [1, !Split [".", !Ref SCIMEndpointUrl]]
+       SecretString: !Ref IdentityStoreID
 +
 +Outputs:
 +  FunctionArn:

--- a/cicd/cloudformation/developer.yaml
+++ b/cicd/cloudformation/developer.yaml
@@ -335,13 +335,13 @@ Resources:
         BuildSpec: "cicd/build/gitvars/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
             Value: !Sub ${ArtifactBucket}
           - Name: GoVersion
-            Value: "1.18.2"
+            Value: "1.20.1"
           - Name: GitRepo
             Value: "https://github.com/awslabs/ssosync"
           - Name: GitBranch
@@ -372,13 +372,13 @@ Resources:
         BuildSpec: "cicd/build/build/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
             Value: !Sub ${ArtifactBucket}
           - Name: GoVersion
-            Value: "1.18.2"
+            Value: "1.20.1"
           - Name: OUTPUT
             Value: main
           - Name: APP_NAME
@@ -409,7 +409,7 @@ Resources:
         BuildSpec: "cicd/build/package/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
@@ -444,7 +444,7 @@ Resources:
         BuildSpec: "cicd/staging/build/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
@@ -477,7 +477,7 @@ Resources:
         BuildSpec: "tests/smoke/cli/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
       Artifacts:
         Name: SSOSync
@@ -505,7 +505,7 @@ Resources:
         BuildSpec: "tests/smoke/lambda/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
       Artifacts:
         Name: SSOSync

--- a/cicd/cloudformation/developer.yaml
+++ b/cicd/cloudformation/developer.yaml
@@ -260,7 +260,7 @@ Resources:
                 Capabilities: CAPABILITY_IAM,CAPABILITY_AUTO_EXPAND
                 StackName: SmokeTest
                 RoleArn: !GetAtt [CloudFormationDeployerRole, Arn]
-                TemplateConfiguration: !Sub 'Tests::deploy/params.json'
+                TemplateConfiguration: !Sub 'Tests::deploy/developer.json'
                 TemplatePath: !Sub 'Tests::deploy/stack.yml'
               InputArtifacts:
                 - Name: Tests

--- a/cicd/cloudformation/developer.yaml
+++ b/cicd/cloudformation/developer.yaml
@@ -340,8 +340,6 @@ Resources:
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
             Value: !Sub ${ArtifactBucket}
-          - Name: GoVersion
-            Value: "1.20.1"
           - Name: GitRepo
             Value: "https://github.com/awslabs/ssosync"
           - Name: GitBranch
@@ -377,8 +375,6 @@ Resources:
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
             Value: !Sub ${ArtifactBucket}
-          - Name: GoVersion
-            Value: "1.20.1"
           - Name: OUTPUT
             Value: main
           - Name: APP_NAME

--- a/cicd/cloudformation/release.yaml
+++ b/cicd/cloudformation/release.yaml
@@ -360,7 +360,7 @@ Resources:
         BuildSpec: "cicd/build/gitvars/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
@@ -397,13 +397,13 @@ Resources:
         BuildSpec: "cicd/build/build/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
             Value: !Sub ${ArtifactBucket}
           - Name: GoVersion
-            Value: "1.18.2"
+            Value: "1.20.1"
           - Name: OUTPUT
             Value: main
           - Name: APP_NAME
@@ -434,7 +434,7 @@ Resources:
         BuildSpec: "cicd/build/package/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
@@ -469,7 +469,7 @@ Resources:
         BuildSpec: "cicd/staging/build/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
@@ -504,7 +504,7 @@ Resources:
         BuildSpec: "cicd/staging/testing/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: TARGETS3BUCKET
@@ -531,7 +531,7 @@ Resources:
         BuildSpec: "cicd/staging/testing/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: TARGETS3BUCKET
@@ -558,7 +558,7 @@ Resources:
         BuildSpec: "cicd/staging/testing/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: TARGETS3BUCKET
@@ -591,7 +591,7 @@ Resources:
         BuildSpec: "cicd/release/approve/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
@@ -622,7 +622,7 @@ Resources:
         BuildSpec: "cicd/release/public/buildspec.yml"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:5.0
+        Image: aws/codebuild/standard:7.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET

--- a/cicd/cloudformation/release.yaml
+++ b/cicd/cloudformation/release.yaml
@@ -89,6 +89,8 @@ Resources:
 
   ArtifactBucketKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Delete
     Properties: 
       Description: Key for this CodePipeline
       Enabled: true

--- a/cicd/cloudformation/release.yaml
+++ b/cicd/cloudformation/release.yaml
@@ -365,8 +365,6 @@ Resources:
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
             Value: !Sub ${ArtifactBucket}
-          - Name: GoVersion
-            Value: "1.18.2"
           - Name: GitRepo 
             Value: "https://github.com/awslabs/ssosync"
           - Name: GitBranch
@@ -402,8 +400,6 @@ Resources:
         EnvironmentVariables:
           - Name: ARTIFACT_S3_BUCKET
             Value: !Sub ${ArtifactBucket}
-          - Name: GoVersion
-            Value: "1.20.1"
           - Name: OUTPUT
             Value: main
           - Name: APP_NAME

--- a/cicd/cloudformation/secrets.yaml
+++ b/cicd/cloudformation/secrets.yaml
@@ -6,71 +6,147 @@ Description:
   (via privately shared app in the AWS Serverless Application Repository (SAR).
 
 Parameters:
+  GoogleAuthMethod:
+    Type: String
+    AllowedValues: ["Google Credentials", "Workload Identity Federation", "Both"]
+    Default: "Google Credentials"
   GoogleCredentials:
-    Description: Credentials to log into Google (content of credentials.json)
+    Description: Google Workspaces Credentials File, to log into Google (content of credentials.json)
     Type: String
     NoEcho: true
   GoogleAdminEmail:
     Description: Google Workspaces Admin email
     Type: String
     NoEcho: true
+  WIFServiceAccountEmail:
+    Description: Workload Identity Federation, the email address of service account used to impersonate a user using 
+    Type: String
+    NoEcho: true
+  WIFClientLibraryConfig:
+    Description: Workload Identity Federation, the client library config file for the provider (AWS Account)  (contents of clientLibraryConfig-provider.json)
+    Type: String
+    NoEcho: true
   SCIMEndpointUrl:
     Description: AWS IAM Identity Center SCIM Endpoint Url
     Type: String
     NoEcho: true
+    AllowedPattern: "https://scim.(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-([0-9]{1}).amazonaws.com/(.*)-([a-z0-9]{4})-([a-z0-9]{4})-([a-z0-9]{12})/scim/v2/"
   SCIMEndpointAccessToken:
     Description: AWS IAM Identity Center SCIM AccessToken
     Type: String
     NoEcho: true  
-  Region:
-    Description: Region in which IAM Identity Center is deployed
-    Type: String
   IdentityStoreId:
     Description: The Id of the Identity Store for the AWS IAM Identity Center instance see (settings page)
     Type: String
+    AllowedPattern: "d-[1-z0-9]{10}"
     
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: Google Workspace
+          default: Google Authentication Method
+        Parameters:
+          - GoogleAuthMethod
+      - Label:
+          default: Parameters for Google Credentials based authentication, required if either Google Credentials or Both have been selected for Google Authentication Method
         Parameters:
           - GoogleAdminEmail
           - GoogleCredentials
+      - Label: 
+          default: Parameters for Workload Identity Federation based authentication, required if either Workload Identity Federation or Both have been selected for Google Authentication Method
+        Parameters:
+          - WIFServiceAccountEmail
+          - WIFClientLibraryConfig
       - Label:
-          default: AWS SSO
+          default: AWS IAM Identity Center
         Parameters:
           - SCIMEndpointUrl
           - SCIMEndpointAccessToken
+          - IdentityStoreId
             
     ParameterLabels:
+      GoogleAuthMethod:
+        default: "Which Google Auth Methods do you want to test with?"
       GoogleCredentials:
         default: "contents of credentials.json"
       GoogleAdminEmail:
         default: "admin@WorkspaceDomain"
+      WIFServiceAccountEmail:
+        default: "service-account@@WorkspaceDomain"
+      WIFClientLibraryConfig:
+        default: "contents of clientLibraryConfig-provider.json"
       SCIMEndpointUrl:
         default: "https://scim.<region>.amazonaws.com/<instance id>/scim/v2/"
       SCIMEndpointAccessToken:
         default: "AWS SSO SCIM Access Token"
-      Region:
-        default: "us-east-1"
       IdentityStoreId:
         default: "d-1234567abc"
 
+Conditions:
+  GoogleCreds: !Or [!Equals [!Ref "GoogleAuthMethod", Google Credentials], !Equals [!Ref "GoogleAuthMethod", Both]]
+  WIFCreds: !Or [!Equals [!Ref "GoogleAuthMethod", Workload Identity Federation], !Equals [!Ref "GoogleAuthMethod", Both]]
+
+
+Rules:
+  # Fail when any assertion returns false
+  # If they have selected Google Credentials then check they have provided valid data for GoogleCredentials
+  GoogleCredentialsOnly:
+    RuleCondition: !Or [!Equals [!Ref "GoogleAuthMethod", Google Credentials], !Equals [!Ref "GoogleAuthMethod", Both]]
+    Assertions:
+      - AssertDescription: You have selected Google Credentials, You need to provide a Google Admin email address.
+        Assert: !Not
+          - !Equals
+            - !Ref GoogleAdminEmail
+            - "" 
+      - AssertDescription: You have selected Google Credentials, You need to provide the content of a Credentials file (json).
+        Assert: !Not
+          - !Equals
+            - !Ref GoogleCredentials
+            - ""
+  # If they have selected Workload Identity Federation, then check they have provide valid data for WIF
+  WorkloadIdentityFederationOnly:
+    RuleCondition: !Or [!Equals [!Ref "GoogleAuthMethod", Workload Identity Federation], !Equals [!Ref "GoogleAuthMethod", Both]]
+    Assertions:
+      - AssertDescription: You have selected Workload Identity Federation, You need to provide a Google Service Account email address.
+        Assert: !Not
+          - !Equals
+            - !Ref WIFServiceAccountEmail
+            - ""
+      - AssertDescription: You have selected Workload Identity Federation, You need to provide the content of a Client Library Config file (json).
+        Assert: !Not
+          - !Equals
+            - !Ref WIFClientLibraryConfig
+            - ""
+
 Resources:
-  
   GoogleCredentialSecret:
     Type: "AWS::SecretsManager::Secret"
+    Condition: GoogleCreds
     Properties:
       Name: TestGoogleCredentials
       SecretString: !Ref GoogleCredentials
 
   GoogleAdminEmailSecret:
     Type: "AWS::SecretsManager::Secret"
+    Condition: GoogleCreds
     Properties:
       Name: TestGoogleAdminEmail
       SecretString: !Ref GoogleAdminEmail
+
+  WIFServiceAccountEmailSecret:
+    Type: "AWS::SecretsManager::Secret"
+    Condition: WIFCreds
+    Properties:
+      Name: TestWIFServiceAccountEmail
+      SecretString: !Ref WIFServiceAccountEmail
+
+  WIFClientLibraryConfigSecret:
+    Type: "AWS::SecretsManager::Secret"
+    Condition: WIFCreds
+    Properties:
+      Name: TestWIFClientLibraryConfigSecret
+      SecretString: !Ref WIFClientLibraryConfig
 
   SSoSCIMUrlSecret: # This can be moved to custom provider
     Type: "AWS::SecretsManager::Secret"
@@ -88,7 +164,7 @@ Resources:
     Type: "AWS::SecretsManager::Secret"
     Properties:
       Name: TestRegion
-      SecretString: !Ref Region
+      SecretString: !Select [1, !Split [".", !Ref SCIMEndpointUrl]]
 
   IdentityStoreIdSecret:
     Type: "AWS::SecretsManager::Secret"

--- a/cicd/cloudformation/testing.yaml
+++ b/cicd/cloudformation/testing.yaml
@@ -466,6 +466,7 @@ Resources:
                 - "identitystore:IsMemberInGroups"
                 - "identitystore:GetGroupMembershipId"
                 - "identitystore:DeleteGroupMembership"
+                - "identitystore:DeleteGroup"
               Effect: Allow
               Resource: '*'
             - Action:

--- a/cicd/cloudformation/testing.yaml
+++ b/cicd/cloudformation/testing.yaml
@@ -182,7 +182,7 @@ Resources:
                 Capabilities: CAPABILITY_IAM,CAPABILITY_AUTO_EXPAND
                 StackName: SmokeTest
                 RoleArn: !GetAtt [CloudFormationDeployerRole, Arn]
-                TemplateConfiguration: !Sub 'Tests::deploy/params.json'
+                TemplateConfiguration: !If [DeployManagement, 'Tests::deploy/management.json', !If [DeployDelegated, 'Tests::deploy/delegated.json', 'Tests::deploy/nondelegated.json']] 
                 TemplatePath: !Sub 'Tests::deploy/stack.yml'
               InputArtifacts:
                 - Name: Tests

--- a/cicd/staging/build/buildspec.yml
+++ b/cicd/staging/build/buildspec.yml
@@ -49,7 +49,15 @@ phases:
       - mkdir deploy
       - cp cicd/staging/build/stack.yml ./deploy/
 
-      # Update params with the values for this run for the management
+      # Update params with the values for this run for a developer account
+      - |
+        jq -n \
+        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GroupMatch\": \"name:AWS*\"}" \
+        --argjson StackPolicy "{\"Statement\":[{\"Effect\": \"Allow\", \"NotAction\": \"Update:Delete\", \"Principal\": \"*\", \"Resource\": \"*\"}]}" \
+        '$ARGS.named' > ./deploy/developer.json
+      - cat ./deploy/developer.json
+
+      # Update params with the values for this run for the management account
       - |
         jq -n \
         --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GroupMatch\": \"name:Man*\"}" \

--- a/cicd/staging/build/buildspec.yml
+++ b/cicd/staging/build/buildspec.yml
@@ -49,13 +49,30 @@ phases:
       - mkdir deploy
       - cp cicd/staging/build/stack.yml ./deploy/
 
-      # Update params with the values for this run
+      # Update params with the values for this run for the management
       - |
         jq -n \
-        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\"}" \
+        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GoogleGroupMatch\": \"name: Man*\"}" \
         --argjson StackPolicy "{\"Statement\":[{\"Effect\": \"Allow\", \"NotAction\": \"Update:Delete\", \"Principal\": \"*\", \"Resource\": \"*\"}]}" \
-        '$ARGS.named' > ./deploy/params.json
-      - cat ./deploy/params.json
+        '$ARGS.named' > ./deploy/management.json
+      - cat ./deploy/management.json
+
+      # Update params with the values for this run for the delegated account
+      - |
+        jq -n \
+        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GoogleGroupMatch\": \"name: Del*\"}" \
+        --argjson StackPolicy "{\"Statement\":[{\"Effect\": \"Allow\", \"NotAction\": \"Update:Delete\", \"Principal\": \"*\", \"Resource\": \"*\"}]}" \
+        '$ARGS.named' > ./deploy/delegated.json
+      - cat ./deploy/delegated.json
+
+      # Update params with the values for this run for non-delegated account
+      - |
+        jq -n \
+        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GoogleGroupMatch\": \"name: Non*\"}" \
+        --argjson StackPolicy "{\"Statement\":[{\"Effect\": \"Allow\", \"NotAction\": \"Update:Delete\", \"Principal\": \"*\", \"Resource\": \"*\"}]}" \
+        '$ARGS.named' > ./deploy/nondelegated.json
+      - cat ./deploy/nondelegated.json
+
 
 artifacts:
   files:

--- a/cicd/staging/build/buildspec.yml
+++ b/cicd/staging/build/buildspec.yml
@@ -52,7 +52,7 @@ phases:
       # Update params with the values for this run for the management
       - |
         jq -n \
-        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GoogleGroupMatch\": \"name: Man*\"}" \
+        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GroupMatch\": \"name:Man*\"}" \
         --argjson StackPolicy "{\"Statement\":[{\"Effect\": \"Allow\", \"NotAction\": \"Update:Delete\", \"Principal\": \"*\", \"Resource\": \"*\"}]}" \
         '$ARGS.named' > ./deploy/management.json
       - cat ./deploy/management.json
@@ -60,7 +60,7 @@ phases:
       # Update params with the values for this run for the delegated account
       - |
         jq -n \
-        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GoogleGroupMatch\": \"name: Del*\"}" \
+        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GroupMatch\": \"name:Del*\"}" \
         --argjson StackPolicy "{\"Statement\":[{\"Effect\": \"Allow\", \"NotAction\": \"Update:Delete\", \"Principal\": \"*\", \"Resource\": \"*\"}]}" \
         '$ARGS.named' > ./deploy/delegated.json
       - cat ./deploy/delegated.json
@@ -68,7 +68,7 @@ phases:
       # Update params with the values for this run for non-delegated account
       - |
         jq -n \
-        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GoogleGroupMatch\": \"name: Non*\"}" \
+        --argjson Parameters "{\"AppArn\": \"$AppArn\", \"AppVersion\": \"$AppVersion\", \"GroupMatch\": \"name:Non*\"}" \
         --argjson StackPolicy "{\"Statement\":[{\"Effect\": \"Allow\", \"NotAction\": \"Update:Delete\", \"Principal\": \"*\", \"Resource\": \"*\"}]}" \
         '$ARGS.named' > ./deploy/nondelegated.json
       - cat ./deploy/nondelegated.json

--- a/cicd/staging/build/stack.yml
+++ b/cicd/staging/build/stack.yml
@@ -15,6 +15,10 @@ Parameters:
     Description: The version of this build in SAR
     Default: 'v1.0.0-rc.10'
     Type: String
+  GroupMatch:
+    Description: The search string to match Groups in Google Workspace
+    Default: 'name:AWS*'
+    Type: String
 
 Resources:
   SARApp:
@@ -32,7 +36,7 @@ Resources:
         IdentityStoreID: '{{resolve:secretsmanager:TestIdentityStoreId}}'
         SyncMethod: groups
         GoogleUserMatch: 'name:*'
-        GoogleGroupMatch: 'name:AWS*'
+        GoogleGroupMatch: !Ref GroupMatch
         LogLevel: warn
         LogFormat: json
         IgnoreUsers: None

--- a/cicd/staging/build/stack.yml
+++ b/cicd/staging/build/stack.yml
@@ -28,6 +28,7 @@ Resources:
         ApplicationId: !Ref AppArn
         SemanticVersion: !Ref AppVersion
       Parameters:
+        FunctionName: SSOSyncFunction
         GoogleAdminEmail: '{{resolve:secretsmanager:TestGoogleAdminEmail}}'
         GoogleCredentials: '{{resolve:secretsmanager:TestGoogleCredentials}}'
         SCIMEndpointUrl: '{{resolve:secretsmanager:TestSCIMEndpointUrl}}'
@@ -35,26 +36,6 @@ Resources:
         Region: '{{resolve:secretsmanager:TestRegion}}'
         IdentityStoreID: '{{resolve:secretsmanager:TestIdentityStoreId}}'
         SyncMethod: groups
-        GoogleUserMatch: '*'
         GoogleGroupMatch: !Ref GroupMatch
         LogLevel: warn
         LogFormat: json
-        IgnoreUsers: None
-        IgnoreGroups: None
-        IncludeGroups: None
-        ScheduleExpression: 'rate(1 day)'
-
-  FunctionArnParam:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: "/SSOSync/Staging/FunctionArn"
-      Type: String
-      Value: !GetAtt SARApp.Outputs.FunctionArn
-      Description: The Arn of the lambda function ssosync
- 
-Outputs:
-  FunctionArn:
-    Description: "The Arn of the deployed lambda function"
-    Value: !GetAtt SARApp.Outputs.FunctionArn
-    Export:
-      Name: FunctionArn

--- a/cicd/staging/build/stack.yml
+++ b/cicd/staging/build/stack.yml
@@ -32,7 +32,6 @@ Resources:
         GoogleCredentials: '{{resolve:secretsmanager:TestGoogleCredentials}}'
         SCIMEndpointUrl: '{{resolve:secretsmanager:TestSCIMEndpointUrl}}'
         SCIMEndpointAccessToken: '{{resolve:secretsmanager:TestSCIMAccessToken}}'
-        Region: '{{resolve:secretsmanager:TestRegion}}'
         IdentityStoreID: '{{resolve:secretsmanager:TestIdentityStoreId}}'
         SyncMethod: groups
         GoogleUserMatch: 'name:*'

--- a/cicd/staging/build/stack.yml
+++ b/cicd/staging/build/stack.yml
@@ -32,6 +32,7 @@ Resources:
         GoogleCredentials: '{{resolve:secretsmanager:TestGoogleCredentials}}'
         SCIMEndpointUrl: '{{resolve:secretsmanager:TestSCIMEndpointUrl}}'
         SCIMEndpointAccessToken: '{{resolve:secretsmanager:TestSCIMAccessToken}}'
+        Region: '{{resolve:secretsmanager:TestRegion}}'
         IdentityStoreID: '{{resolve:secretsmanager:TestIdentityStoreId}}'
         SyncMethod: groups
         GoogleUserMatch: '*'

--- a/cicd/staging/build/stack.yml
+++ b/cicd/staging/build/stack.yml
@@ -34,7 +34,7 @@ Resources:
         SCIMEndpointAccessToken: '{{resolve:secretsmanager:TestSCIMAccessToken}}'
         IdentityStoreID: '{{resolve:secretsmanager:TestIdentityStoreId}}'
         SyncMethod: groups
-        GoogleUserMatch: 'name:*'
+        GoogleUserMatch: '*'
         GoogleGroupMatch: !Ref GroupMatch
         LogLevel: warn
         LogFormat: json

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -136,7 +136,7 @@ func Handler(ctx context.Context, event events.CodePipelineEvent) (string, error
 func init() {
 	// init config
 	cfg = config.New()
-	cfg.IsLambda = len(os.Getenv("_LAMBDA_SERVER_PORT")) > 0
+	cfg.IsLambda = len(os.Getenv("AWS_LAMBDA_FUNCTION_NAME")) > 0
 
 	// initialize cobra
 	cobra.OnInitialize(initConfig)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,7 +96,6 @@ func Handler(ctx context.Context, event InputConfig) (string, error) {
 
 func init() {
 	// init config
-	log.Info("Initializing cobra config")
 	cfg = config.New()
 	cfg.IsLambda = len(os.Getenv("AWS_LAMBDA_FUNCTION_NAME")) > 0
 
@@ -159,12 +158,11 @@ func initConfig() {
 	// }
 
 	if cfg.IsLambda {
-		// configLambda()
+		configLambda()
 	}
 }
 
 func configLambda() {
-	log.Info("meep")
 	s := session.Must(session.NewSession())
 	svc := secretsmanager.New(s)
 	secrets := config.NewSecrets(svc)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,14 +20,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/awslabs/ssosync/internal"
-	"github.com/awslabs/ssosync/internal/config"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-lambda-go/events"
-        "github.com/aws/aws-sdk-go/service/codepipeline"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/awslabs/ssosync/internal"
+	"github.com/awslabs/ssosync/internal/config"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -66,9 +63,9 @@ Complete documentation is available at https://github.com/awslabs/ssosync`,
 // running inside of AWS Lambda, we use the Lambda
 // execution path.
 func Execute() {
-        if cfg.IsLambda {
-                log.Info("Executing as Lambda")
-        	lambda.Start(Handler) 
+	if cfg.IsLambda {
+		log.Info("Executing as Lambda")
+		lambda.Start(Handler)
 	}
 
 	if err := rootCmd.Execute(); err != nil {
@@ -76,61 +73,22 @@ func Execute() {
 	}
 }
 
-func Handler(ctx context.Context, event events.CodePipelineEvent) (string, error) {
-    log.Debug(event)
-    err := rootCmd.Execute()
-    s := session.Must(session.NewSession())
-    cpl := codepipeline.New(s)
+// Struct for optional input parameters
+type InputEvent struct {
+	GroupName string `json:"group_name"`
+	UserName  string `json:"user_name"`
+}
 
-    cfg.IsLambdaRunningInCodePipeline = len(event.CodePipelineJob.ID) > 0
+func Handler(ctx context.Context, event InputEvent) (string, error) {
+	log.Info(event)
+	err := rootCmd.Execute()
 
-    if cfg.IsLambdaRunningInCodePipeline {
-        log.Info("Lambda has been invoked by CodePipeline")
-
-        if err != nil {
-    	    // notify codepipeline and mark its job execution as Failure
-    	    log.Fatalf(errors.Wrap(err, "Notifying CodePipeline and mark its job execution as Failure").Error())
-    	    jobID := event.CodePipelineJob.ID
-    	    if len(jobID) == 0 {
-    		panic("CodePipeline Job ID is not set")
-    	    }  
-    	    // mark the job as Failure.
-    	    cplFailure := &codepipeline.PutJobFailureResultInput{
-    		JobId: aws.String(jobID),
-    		FailureDetails: &codepipeline.FailureDetails{
-    			Message: aws.String(err.Error()),
-    			Type: aws.String("JobFailed"),
-    		},
-    	    }
-    	    _, cplErr := cpl.PutJobFailureResult(cplFailure)
-    	    if cplErr != nil {
-                log.Fatalf(errors.Wrap(err, "Failed to update CodePipeline jobID status").Error())
-    	    }
-    	    return "Failure", err
-        } else {
-            log.Info("Notifying CodePipeline and mark its job execution as Success")
-            jobID := event.CodePipelineJob.ID
-            if len(jobID) == 0 {
-    	       panic("CodePipeline Job ID is not set")
-            }
-            // mark the job as Success.
-            cplSuccess := &codepipeline.PutJobSuccessResultInput{
-    	       JobId: aws.String(jobID),
-            }
-            _, cplErr := cpl.PutJobSuccessResult(cplSuccess)
-            if cplErr != nil {
-                log.Fatalf(errors.Wrap(err, "Failed to update CodePipeline jobID status").Error())
-            }
-            return "Success", nil
-        }
-    } else {
-        if err != nil {
-            log.Fatalf(errors.Wrap(err, "Notifying Lambda and mark this execution as Failure").Error())
-            return "Failure", err
-        } else {
-            return "Success", nil
-        }
-    }
+	if err != nil {
+		log.Fatalf(errors.Wrap(err, "Notifying Lambda and mark this execution as Failure").Error())
+		return "Failure", err
+	} else {
+		return "Success", nil
+	}
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ func Execute() {
 // Struct for optional input parameters
 type InputConfig struct {
 	GroupName string `json:"group_name"`
-	// UserName  string `json:"user_name"`
+	// UserName  string `json:"user_name"` // Optionall can add in the future to filter on a specific user
 }
 
 func Handler(ctx context.Context, event InputConfig) (string, error) {
@@ -152,6 +152,7 @@ func initConfig() {
 		log.Infof("Overriding GroupMatch with %s", inputConfig.GroupName)
 	}
 
+	// Optionally in the future we could match on a specific user as well if better performance is needed
 	// if inputConfig.UserName != "" {
 	// 	cfg.UserMatch = inputConfig.UserName
 	// 	log.Infof("Overriding UserMatch with %s", inputConfig.UserName)

--- a/template.yaml
+++ b/template.yaml
@@ -93,22 +93,27 @@ Parameters:
     Type: String
     Description: |
       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
+    Default: '*'
   GoogleGroupMatch:
     Type: String
     Description: |
       Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
+    Default: 'name:AWS*'
   IgnoreGroups:
     Type: String
     Description: |
       Ignore these Google Workspace groups
+    Default: 'none'
   IgnoreUsers:
     Type: String
     Description: |
       Ignore these Google Workspace users
+    Default: 'none'
   IncludeGroups:
     Type: String
     Description: |
       Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
+    Default: '*'
   SyncMethod:
     Type: String
     Description: Sync method to use

--- a/template.yaml
+++ b/template.yaml
@@ -119,6 +119,7 @@ Parameters:
     Type: String
     Description: |
       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
+    Default: ""
     AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   GoogleGroupMatch:
     Type: String
@@ -130,16 +131,19 @@ Parameters:
     Type: String
     Description: |
       Ignore these Google Workspace groups, leave empty if not required
+    Default: ""
     AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   IgnoreUsers:
     Type: String
     Description: |
       Ignore these Google Workspace users, leave empty if not required
+    Default: ""
     AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   IncludeGroups:
     Type: String
     Description: |
       Include only these Google Workspace groups, leave empty if not required. (Only applicable for SyncMethod user_groups)
+    Default: ""
     AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   SyncMethod:
     Type: String

--- a/template.yaml
+++ b/template.yaml
@@ -50,7 +50,7 @@ Metadata:
     # Update the semantic version and run sam publish to publish a new version of your app
     SemanticVersion: 1.0.0-rc.10
     # best practice is to use git tags for each release and link to the version tag as your source code URL
-    SourceCodeUrl: https://github.com/awslabs/ssosync/tree/1.0.0-rc.10
+    SourceCodeUrl: https://github.com/awslabs/ssosync/
 
 Parameters:
   FunctionName:
@@ -81,6 +81,11 @@ Parameters:
     AllowedValues:
       - json
       - text
+  LogRetention:
+    Type: String
+    Description: Number of days to retain Logs for, leave empty to retain them indefinitely
+    Default: ""
+    AllowedPattern: '(?!.*\s)|/d'
   TimeOut:
     Type: Number
     Description: Timeout for the Lambda function
@@ -88,66 +93,96 @@ Parameters:
     MinValue: 1
     MaxValue: 900
 
+
   GoogleCredentials:
     Type: String
-    Description: Credentials to log into Google (content of credentials.json)
+    Description: |
+      Credentials to log into Google (content of credentials.json)
+    ConstraintDescription: |
+      You should save this information when following this setup https://developers.google.com/admin-sdk/directory/v1/guides/delegation
     NoEcho: true
   GoogleAdminEmail:
     Type: String
-    Description: Google Admin email
+    Description: |
+      Google Admin email
+    ConstraintDescription: |
+      This is a use with admin authority on your Google Directory, you will have used this when following this setup https://developers.google.com/admin-sdk/directory/v1/guides/delegation
     NoEcho: true
   SCIMEndpointUrl:
     Type: String
-    Description: AWS IAM Identity Center - SCIM Endpoint Url
-    NoEcho: true
+    Description: |
+      AWS IAM Identity Center - SCIM Endpoint Url
     AllowedPattern: "https://scim.(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-([0-9]{1}).amazonaws.com/(.*)-([a-z0-9]{4})-([a-z0-9]{4})-([a-z0-9]{12})/scim/v2/"
+    ConstraintDescription: |
+      You should save this information when following this setup https://docs.aws.amazon.com/singlesignon/latest/userguide/provision-automatically.html
+    NoEcho: true
   SCIMEndpointAccessToken:
     Type: String
-    Description: AWS IAM Identity Center - SCIM AccessToken
+    Description: |
+      AWS IAM Identity Center - SCIM AccessToken
+    ConstraintDescription: |
+      You should save this information when following this setup https://docs.aws.amazon.com/singlesignon/latest/userguide/provision-automatically.html
     NoEcho: true
   Region:
     Type: String
-    Description: AWS Region where AWS IAM Identity Center is enabled
+    Description: |
+      AWS Region where AWS IAM Identity Center is enabled
+    ConstraintDescription: |
+      You can find this value on the settings page of the IAM Identity Center console page
     AllowedPattern: '(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d'
   IdentityStoreID:
     Type: String
-    Description: Identifier of Identity Store in AWS IAM Identity Center
+    Description: |
+      Identifier of Identity Store in AWS IAM Identity Center
+    ConstraintDescription: |
+      You can find this value on the settings page of the IAM Identity Center console page
     NoEcho: true
     AllowedPattern: 'd-[1-z0-9]{10}'
 
   GoogleUserMatch:
     Type: String
     Description: |
-      Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
+      Google Workspace user filter query parameter, example: 'name:John* email:admin*', leave empty if you do not wish to pass this parameter 
+    ConstraintDescription: |
+      The parameter needs to be compliant with the Google admin-sdk api, https://developers.google.com/admin-sdk/directory/v1/guides/search-users
     Default: ""
     AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   GoogleGroupMatch:
     Type: String
     Description: |
-      Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
+      Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', leave empty if you do not wish to pass this parameter
+    ConstraintDescription: |
+      The parameter needs to be compliant with the Google admin-sdk api, see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
     Default: 'name:AWS*'
     AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   IgnoreGroups:
     Type: String
     Description: |
-      Ignore these Google Workspace groups, leave empty if not required
+      Do NOT sync these Google Workspace groups into IAM Identity Center, leave empty if not required
+    ConstraintDescription: |
+      This should be a comma separated list of group names
     Default: ""
-    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
+    AllowedPattern: '(?!.*\s)|(["0-9a-zA-Z-=@. _]*)(,["0-9a-zA-Z-=@. _]*)*'
   IgnoreUsers:
     Type: String
     Description: |
       Ignore these Google Workspace users, leave empty if not required
+    ConstraintDescription: |
+      This should be a comma separated list of group names
     Default: ""
     AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   IncludeGroups:
     Type: String
     Description: |
       Include only these Google Workspace groups, leave empty if not required. (Only applicable for SyncMethod user_groups)
+    ConstraintDescription: |
+      This should be a comma separated list of group names
     Default: ""
     AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   SyncMethod:
     Type: String
-    Description: Sync method to use
+    Description: |
+      Which sync method do you want to use with ssosync?
     Default: groups
     AllowedValues:
       - groups
@@ -161,7 +196,8 @@ Conditions:
   SetIgnoreGroups: !Not [!Equals [!Ref "IgnoreGroups", ""]]
   SetIgnoreUsers: !Not [!Equals [!Ref "IgnoreUsers", ""]]
   SetIncludeGroups: !Or [!Not [!Equals [!Ref "IncludeGroups", ""]], !Equals [!Ref "SyncMethod", groups]]
-
+  NotIndefinite: !Not [!Equals [!Ref "LogRetention", ""]]
+    
 Resources:
   SSOSyncFunction:
     Type: AWS::Serverless::Function
@@ -230,6 +266,15 @@ Resources:
           Properties:
             Enabled: !If [OnSchedule, false, true]
             Schedule: !If [OnSchedule, !Ref ScheduleExpression, "rate(15 minutes)"]
+
+  # Explicit log group that refers to the Lambda function
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: NotIndefinite
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${SSOSyncFunction}"
+      # Explicit retention time
+      RetentionInDays: !Ref LogRetention
 
   AWSGoogleCredentialsSecret:
     Type: "AWS::SecretsManager::Secret"

--- a/template.yaml
+++ b/template.yaml
@@ -25,6 +25,7 @@ Metadata:
           - IgnoreUsers
           - IgnoreGroups
           - IncludeGroups
+          - Timeout
 
   AWS::ServerlessRepo::Application:
     Name: ssosync
@@ -116,7 +117,12 @@ Parameters:
     AllowedValues:
       - groups
       - users_groups
-
+  Timeout:
+    Type: Number
+    Description: Timeout for the Lambda function
+    Default: 300
+    MinValue: 0
+    MaxValue: 900
 
 
 
@@ -126,7 +132,7 @@ Resources:
     Properties:
       Runtime: go1.x
       Handler: dist/ssosync_linux_amd64_v1/ssosync
-      Timeout: 300
+      Timeout: !Ref Timeout
       Environment:
         Variables:
           SSOSYNC_LOG_LEVEL: !Ref LogLevel

--- a/template.yaml
+++ b/template.yaml
@@ -9,7 +9,7 @@ Metadata:
         Parameters:
           - SCIMEndpointUrl
           - SCIMEndpointAccessToken
-          - IdentityStoreId
+          - IdentityStoreID
       - Label:
           default: Google Workspace Credentials 
         Parameters:
@@ -98,10 +98,6 @@ Parameters:
     Type: String
     Description: AWS SSO SCIM AccessToken
     NoEcho: true
-  Region:
-    Type: String
-    Description: AWS Region where AWS SSO is enabled
-    NoEcho: true
   IdentityStoreID:
     Type: String
     Description: Identifier of Identity Store in AWS SSO
@@ -113,13 +109,13 @@ Parameters:
     Description: |
       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
     Default: '*'
-    AllowedPattern: "(*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))"
+    AllowedPattern: '(*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   GoogleGroupMatch:
     Type: String
     Description: |
       Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
     Default: 'name:AWS*'
-    AllowedPattern: "((name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64})))|((email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260})))"
+    AllowedPattern: '(name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   IgnoreGroups:
     Type: String
     Description: |

--- a/template.yaml
+++ b/template.yaml
@@ -56,6 +56,8 @@ Parameters:
     Type: String
     Description: Schedule for trigger the execution of ssosync (see CloudWatch schedule expressions)
     Default: rate(15 minutes)
+    AllowedPattern: '^rate\((?:1\s(?:hour|minute|day)|(?:[2-9]|[1-9][0-9]+)\s(?:hours|minutes|days))\)|cron\(\s*(?:\*|(?<minutes>0|[1-5]{0,1}[0-9]?)(?:(?:,(?P>minutes))*|(?:-(?P>minutes)){0,1}(?:\/[[:digit:]]){0,1}))\s\s*(?:\*|(?<hours>0|[1]{0,1}[0-9]?|2[0-3])(?:(?:,(?P>hours))*|(?:-(?P>hours)){0,1}(?:\/[[:digit:]]){0,1}))\s\s*(?:(?<qDays>\?)|\*(?<days>[1-2]{0,1}[1-9]?|31|10|20|30)(?:(?:,(?P>days))*|(?:-(?P>days)){0,1}(?:\/[[:digit:]]){0,1}|L|W))\s\s*(?:\*|(?<month>[1-9]|1[0-2])(?:(?:,(?P>month))*|(?:-(?P>month)){0,1}(?:\/[[:digit:]]){0,1})|(?<alphamonth>JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(?:(?:,(?P>alphamonth))*|(?:-(?P>alphamonth)){0,1}(?:\/[[:digit:]]){0,1}))\s\s*(?(<qDays>)(?:\*|(?<week>[1-7])(?:(?:,(?P>week))*|(?:-(?P>week)){0,1}(?:\/[[:digit:]]){0,1}|L|#[1-5])|(?<alphaweek>MON|TUE|WED|THU|FRI|SAT|SUN)(?:(?:,(?P>alphaweek))*|(?:-(?P>alphaweek)){0,1}(?:\/[[:digit:]]){0,1}))|\?)\s\s*(?:\*|(?<year>19[7-9][0-9]|2[0-1][0-9][0-9])(?:(?:,(?P>year))*|(?:-(?P>year)){0,1}(?:\/[[:digit:]]){0,1}))\s*\)$
+h'
   LogLevel:
     Type: String
     Description: Log level for Lambda function logging

--- a/template.yaml
+++ b/template.yaml
@@ -56,8 +56,7 @@ Parameters:
     Type: String
     Description: Schedule for trigger the execution of ssosync (see CloudWatch schedule expressions)
     Default: rate(15 minutes)
-    AllowedPattern: '^rate\((?:1\s(?:hour|minute|day)|(?:[2-9]|[1-9][0-9]+)\s(?:hours|minutes|days))\)|cron\(\s*(?:\*|(?<minutes>0|[1-5]{0,1}[0-9]?)(?:(?:,(?P>minutes))*|(?:-(?P>minutes)){0,1}(?:\/[[:digit:]]){0,1}))\s\s*(?:\*|(?<hours>0|[1]{0,1}[0-9]?|2[0-3])(?:(?:,(?P>hours))*|(?:-(?P>hours)){0,1}(?:\/[[:digit:]]){0,1}))\s\s*(?:(?<qDays>\?)|\*(?<days>[1-2]{0,1}[1-9]?|31|10|20|30)(?:(?:,(?P>days))*|(?:-(?P>days)){0,1}(?:\/[[:digit:]]){0,1}|L|W))\s\s*(?:\*|(?<month>[1-9]|1[0-2])(?:(?:,(?P>month))*|(?:-(?P>month)){0,1}(?:\/[[:digit:]]){0,1})|(?<alphamonth>JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(?:(?:,(?P>alphamonth))*|(?:-(?P>alphamonth)){0,1}(?:\/[[:digit:]]){0,1}))\s\s*(?(<qDays>)(?:\*|(?<week>[1-7])(?:(?:,(?P>week))*|(?:-(?P>week)){0,1}(?:\/[[:digit:]]){0,1}|L|#[1-5])|(?<alphaweek>MON|TUE|WED|THU|FRI|SAT|SUN)(?:(?:,(?P>alphaweek))*|(?:-(?P>alphaweek)){0,1}(?:\/[[:digit:]]){0,1}))|\?)\s\s*(?:\*|(?<year>19[7-9][0-9]|2[0-1][0-9][0-9])(?:(?:,(?P>year))*|(?:-(?P>year)){0,1}(?:\/[[:digit:]]){0,1}))\s*\)$
-h'
+    AllowedPattern: '(?!.*\s)|rate\(\d{1,3} (minutes|hours|days)\)|(cron\((([0-9]|[1-5][0-9]|60)|\d\/([0-9]|[1-5][0-9]|60)|\*) (([0-9]|[1][0-9]|[2][0-3])|(\d\/([0-9]|[1][0-9]|[2][0-3]))|(([0-9]|[1][0-9]|[2][0-3])-([0-9]|[1][0-9]|[2][0-3]))|\*) (([1-9]|[1-2][0-9]|[3][0-1])|\d\/([1-9]|[1-2][0-9]|[3][0-1])|[1-5]W|L|\*|\?) (([1-9]|[1][1-2])|(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)|((JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV)-(FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))|(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV)(,(FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)){0,11}|\d\/([0-9]|[1][0-2])|\?|\*) ((MON|TUE|WED|THU|FRI|SAT|SUN)|(MON|TUE|WED|THU|FRI|SAT)-(TUE|WED|THU|FRI|SAT|SUN)|(MON|TUE|WED|THU|FRI|SAT)(,(TUE|WED|THU|FRI|SAT|SUN)){0,6}|[1-7]L|[1-7]#[1-5]|\?|\*) ((19[7-9][0-9]|2[0-1]\d\d)|(19[7-9][0-9]|2[0-1]\d\d)-(19[7-9][0-9]|2[0-1]\d\d)|(19[7-9][0-9]|2[0-1]\d\d)(,(19[7-9][0-9]|2[0-1]\d\d))*|\*)\))'
   LogLevel:
     Type: String
     Description: Log level for Lambda function logging
@@ -115,29 +114,28 @@ h'
     Type: String
     Description: |
       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
-    Default: '*'
-    AllowedPattern: '(^\*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
+    AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   GoogleGroupMatch:
     Type: String
     Description: |
       Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
     Default: 'name:AWS*'
-    AllowedPattern: '(name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
+    AllowedPattern: '(?!.*\s)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   IgnoreGroups:
     Type: String
     Description: |
-      Ignore these Google Workspace groups
-    Default: 'none'
+      Ignore these Google Workspace groups, leave empty if not required
+    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   IgnoreUsers:
     Type: String
     Description: |
-      Ignore these Google Workspace users
-    Default: 'none'
+      Ignore these Google Workspace users, leave empty if not required
+    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   IncludeGroups:
     Type: String
     Description: |
-      Include only these Google Workspace groups. (Only applicable for SyncMethod user_groups)
-    Default: '*'
+      Include only these Google Workspace groups, leave empty if not required. (Only applicable for SyncMethod user_groups)
+    AllowedPattern: '(?!.*\s)|([0-9a-zA-Z-= _]*)(,[0-9a-zA-Z-=@. _]*)*'
   SyncMethod:
     Type: String
     Description: Sync method to use
@@ -145,6 +143,14 @@ h'
     AllowedValues:
       - groups
       - users_groups
+
+Conditions:
+  OnSchedule: !Not [!Equals [!Ref "ScheduleExpression", ""]]
+  NoGoogleUserMatch: !Not [!Equals [!Ref "GoogleUserMatch", ""]]
+  NoGoogleGroupMatch: !Not [!Equals [!Ref "GoogleGroupMatch", ""]]
+  NoIgnoreGroups: !Not [!Equals [!Ref "IgnoreGroups", ""]]
+  NoIgnoreUsers: !Not [!Equals [!Ref "IgnoreUsers", ""]]
+  NoIncludeGroups: !Or [!Equals [!Ref "SyncMethod", groups], !Equals [!Ref "IncludeGroups", ""]]
 
 Resources:
   SSOSyncFunction:
@@ -165,12 +171,12 @@ Resources:
           SSOSYNC_SCIM_ACCESS_TOKEN: !Ref AWSSCIMAccessTokenSecret
           SSOSYNC_REGION: !Ref AWSRegionSecret
           SSOSYNC_IDENTITY_STORE_ID: !Ref AWSIdentityStoreIDSecret
-          SSOSYNC_USER_MATCH: !Ref GoogleUserMatch
-          SSOSYNC_GROUP_MATCH: !Ref GoogleGroupMatch
+          SSOSYNC_USER_MATCH: !If [NoGoogleUserMatch, AWS::NoValue, !Ref GoogleUserMatch]
+          SSOSYNC_GROUP_MATCH: !If [NoGoogleGroupMatch, AWS::NoValue, !Ref GoogleGroupMatch]
           SSOSYNC_SYNC_METHOD: !Ref SyncMethod
-          SSOSYNC_IGNORE_GROUPS: !Ref IgnoreGroups
-          SSOSYNC_IGNORE_USERS: !Ref IgnoreUsers
-          SSOSYNC_INCLUDE_GROUPS: !Ref IncludeGroups
+          SSOSYNC_IGNORE_GROUPS: !If [NoIgnoreGroups, AWS::NoValue, !Ref IgnoreGroups]
+          SSOSYNC_IGNORE_USERS: !If [NoIgnoreUsers, AWS::NoValue, !Ref IgnoreUsers]
+          SSOSYNC_INCLUDE_GROUPS: !If [NoIncludeGroups, AWS::NoValue, !Ref IncludeGroups]
       Policies:
         - Version: '2012-10-17'
           Statement:
@@ -211,8 +217,8 @@ Resources:
           Type: Schedule
           Name: AWSSyncSchedule
           Properties:
-            Enabled: true
-            Schedule: !Ref ScheduleExpression
+            Enabled: !If [OnSchedule, false, true]
+            Schedule: !If [OnSchedule, !Ref ScheduleExpression, "rate(15 minutes)"]
 
   AWSGoogleCredentialsSecret:
     Type: "AWS::SecretsManager::Secret"

--- a/template.yaml
+++ b/template.yaml
@@ -5,26 +5,35 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: "General"
+          default: AWS IAM Identity Center
         Parameters:
-          - GoogleCredentials
-          - GoogleAdminEmail
           - SCIMEndpointUrl
           - SCIMEndpointAccessToken
-          - Region
-          - IdentityStoreID
+          - IdentityStoreId
       - Label:
-          default: "Advanced Configuration"
+          default: Google Workspace Credentials 
+        Parameters:
+          - GoogleAdminEmail
+          - GoogleCredentials
+      - Label:
+          default: Sync Configuration
         Parameters:
           - SyncMethod
           - GoogleUserMatch
           - GoogleGroupMatch
-          - LogLevel
-          - LogFormat
-          - ScheduleExpression
           - IgnoreUsers
           - IgnoreGroups
+      - Label:
+          default: "Configuration options for users_groups Mode only"
+        Parameters:
           - IncludeGroups
+      - Label:
+          default: "Lambda Configuration"
+        Parameters:
+          - LogLevel
+          - LogFormat
+          - TimeOut
+          - ScheduleExpression
 
   AWS::ServerlessRepo::Application:
     Name: ssosync
@@ -65,6 +74,13 @@ Parameters:
     AllowedValues:
       - json
       - text
+  TimeOut:
+    Type: Number
+    Description: Timeout for the Lambda function
+    Default: 300
+    MinValue: 1
+    MaxValue: 900
+
   GoogleCredentials:
     Type: String
     Description: Credentials to log into Google (content of credentials.json)
@@ -77,6 +93,7 @@ Parameters:
     Type: String
     Description: AWS SSO SCIM Endpoint Url
     NoEcho: true
+    AllowedPattern: "https://scim.(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-([0-9]{1}).amazonaws.com/(.*)-([a-z0-9]{4})-([a-z0-9]{4})-([a-z0-9]{12})/scim/v2/"
   SCIMEndpointAccessToken:
     Type: String
     Description: AWS SSO SCIM AccessToken
@@ -89,16 +106,20 @@ Parameters:
     Type: String
     Description: Identifier of Identity Store in AWS SSO
     NoEcho: true
+    AllowedPattern: "d-[1-z0-9]{10}"
+
   GoogleUserMatch:
     Type: String
     Description: |
       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
     Default: '*'
+    AllowedPattern: "(*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))"
   GoogleGroupMatch:
     Type: String
     Description: |
       Google Workspace group filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
     Default: 'name:AWS*'
+    AllowedPattern: "((name|Name|NAME)(:([a-zA-Z0-9]{1,64})\*)|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64})))|((email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})\*)|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260})))"
   IgnoreGroups:
     Type: String
     Description: |
@@ -133,7 +154,7 @@ Resources:
       Handler: dist/ssosync_linux_arm64/ssosync
       Architectures:
         - arm64
-      Timeout: 300
+      Timeout: !Ref TimeOut
       Environment:
         Variables:
           SSOSYNC_LOG_LEVEL: !Ref LogLevel
@@ -180,6 +201,12 @@ Resources:
                 - "identitystore:DeleteGroup"
               Resource:
                 - "*"
+            - Sid: CodePipelinePolicy
+              Effect: Allow
+              Action:
+                - codepipeline:PutJobSuccessResult
+                - codepipeline:PutJobFailureResult
+              Resource: "*"
       Events:
         SyncScheduledEvent:
           Type: Schedule
@@ -218,7 +245,7 @@ Resources:
     Type: "AWS::SecretsManager::Secret"
     Properties:
       Name: SSOSyncRegion
-      SecretString: !Ref Region
+      SecretString: !Select [1, !Split [".", !Ref SCIMEndpointUrl]]
 
   AWSIdentityStoreIDSecret:
     Type: "AWS::SecretsManager::Secret"

--- a/template.yaml
+++ b/template.yaml
@@ -31,6 +31,7 @@ Metadata:
       - Label:
           default: "Lambda Configuration"
         Parameters:
+          - FunctionName
           - LogLevel
           - LogFormat
           - TimeOut
@@ -52,6 +53,10 @@ Metadata:
     SourceCodeUrl: https://github.com/awslabs/ssosync/tree/1.0.0-rc.10
 
 Parameters:
+  FunctionName:
+    Type: String
+    Description: Specify the Function you want to us for this deployment, leave empty for default behaviour.
+    AllowedPattern: '(?!.*\s)|[a-zA-Z0-9-_]{1,140}'
   ScheduleExpression:
     Type: String
     Description: Schedule for trigger the execution of ssosync (see CloudWatch schedule expressions)
@@ -145,6 +150,7 @@ Parameters:
       - users_groups
 
 Conditions:
+  NoFunctionName: !Not [!Equals [!Ref "FunctionName", ""]]
   OnSchedule: !Not [!Equals [!Ref "ScheduleExpression", ""]]
   NoGoogleUserMatch: !Not [!Equals [!Ref "GoogleUserMatch", ""]]
   NoGoogleGroupMatch: !Not [!Equals [!Ref "GoogleGroupMatch", ""]]
@@ -156,6 +162,7 @@ Resources:
   SSOSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
+      FunctionName: !If [NoFunctionName, AWS::NoValue, !Ref FunctionName]
       Runtime: provided.al2
       Handler: bootstrap
       Architectures:
@@ -255,3 +262,10 @@ Resources:
     Properties:
       Name: SSOSyncIdentityStoreID
       SecretString: !Ref IdentityStoreID
+
+Outputs:
+  FunctionArn:
+    Description: "The Arn of the deployed lambda function"
+    Value: !GetAtt SSOSyncFunction.Arn
+    Export:
+      Name: SSOSyncFunctionARN

--- a/template.yaml
+++ b/template.yaml
@@ -5,10 +5,11 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: AWS IAM Identity Center
+          default: AWS IAM Identity Center (Successor to AWS Single Sign-On)
         Parameters:
           - SCIMEndpointUrl
           - SCIMEndpointAccessToken
+          - Region
           - IdentityStoreID
       - Label:
           default: Google Workspace Credentials 
@@ -91,18 +92,22 @@ Parameters:
     NoEcho: true
   SCIMEndpointUrl:
     Type: String
-    Description: AWS SSO SCIM Endpoint Url
+    Description: AWS IAM Identity Center - SCIM Endpoint Url
     NoEcho: true
     AllowedPattern: "https://scim.(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-([0-9]{1}).amazonaws.com/(.*)-([a-z0-9]{4})-([a-z0-9]{4})-([a-z0-9]{12})/scim/v2/"
   SCIMEndpointAccessToken:
     Type: String
-    Description: AWS SSO SCIM AccessToken
+    Description: AWS IAM Identity Center - SCIM AccessToken
     NoEcho: true
+  Region:
+    Type: String
+    Description: AWS Region where AWS IAM Identity Center is enabled
+    AllowedPattern: '(us(-gov)?|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d'
   IdentityStoreID:
     Type: String
-    Description: Identifier of Identity Store in AWS SSO
+    Description: Identifier of Identity Store in AWS IAM Identity Center
     NoEcho: true
-    AllowedPattern: "d-[1-z0-9]{10}"
+    AllowedPattern: 'd-[1-z0-9]{10}'
 
   GoogleUserMatch:
     Type: String
@@ -235,7 +240,7 @@ Resources:
     Type: "AWS::SecretsManager::Secret"
     Properties:
       Name: SSOSyncRegion
-      SecretString: !Select [1, !Split [".", !Ref SCIMEndpointUrl]]
+      SecretString: !Ref Region
 
   AWSIdentityStoreIDSecret:
     Type: "AWS::SecretsManager::Secret"

--- a/template.yaml
+++ b/template.yaml
@@ -109,7 +109,7 @@ Parameters:
     Description: |
       Google Workspace user filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
     Default: '*'
-    AllowedPattern: '(*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
+    AllowedPattern: '(^\*)|(name|Name|NAME)(:([a-zA-Z0-9]{1,64})(\*))|(name|Name|NAME)(=([a-zA-Z0-9 ]{1,64}))|(email|Email|EMAIL)(:([a-zA-Z0-9.-_]{1,64})(\*))|(email|Email|EMAIL)(=([a-zA-Z0-9.-_]{1,64})@([a-zA-Z0-9.-]{5,260}))'
   GoogleGroupMatch:
     Type: String
     Description: |

--- a/template.yaml
+++ b/template.yaml
@@ -130,7 +130,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Runtime: provided.al2
-      Handler: bootstrap
+      Handler: dist/ssosync_linux_arm64/ssosync
       Architectures:
         - arm64
       Timeout: 300

--- a/template.yaml
+++ b/template.yaml
@@ -150,19 +150,19 @@ Parameters:
       - users_groups
 
 Conditions:
-  NoFunctionName: !Not [!Equals [!Ref "FunctionName", ""]]
+  SetFunctionName: !Not [!Equals [!Ref "FunctionName", ""]]
   OnSchedule: !Not [!Equals [!Ref "ScheduleExpression", ""]]
-  NoGoogleUserMatch: !Not [!Equals [!Ref "GoogleUserMatch", ""]]
-  NoGoogleGroupMatch: !Not [!Equals [!Ref "GoogleGroupMatch", ""]]
-  NoIgnoreGroups: !Not [!Equals [!Ref "IgnoreGroups", ""]]
-  NoIgnoreUsers: !Not [!Equals [!Ref "IgnoreUsers", ""]]
-  NoIncludeGroups: !Or [!Equals [!Ref "SyncMethod", groups], !Equals [!Ref "IncludeGroups", ""]]
+  SetGoogleUserMatch: !Not [!Equals [!Ref "GoogleUserMatch", ""]]
+  SetGoogleGroupMatch: !Not [!Equals [!Ref "GoogleGroupMatch", ""]]
+  SetIgnoreGroups: !Not [!Equals [!Ref "IgnoreGroups", ""]]
+  SetIgnoreUsers: !Not [!Equals [!Ref "IgnoreUsers", ""]]
+  SetIncludeGroups: !Or [!Equals [!Ref "SyncMethod", groups], !Equals [!Ref "IncludeGroups", ""]]
 
 Resources:
   SSOSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !If [NoFunctionName, AWS::NoValue, !Ref FunctionName]
+      FunctionName: !If [SetFunctionName, !Ref FunctionName, AWS::NoValue]
       Runtime: provided.al2
       Handler: bootstrap
       Architectures:
@@ -178,12 +178,12 @@ Resources:
           SSOSYNC_SCIM_ACCESS_TOKEN: !Ref AWSSCIMAccessTokenSecret
           SSOSYNC_REGION: !Ref AWSRegionSecret
           SSOSYNC_IDENTITY_STORE_ID: !Ref AWSIdentityStoreIDSecret
-          SSOSYNC_USER_MATCH: !If [NoGoogleUserMatch, AWS::NoValue, !Ref GoogleUserMatch]
-          SSOSYNC_GROUP_MATCH: !If [NoGoogleGroupMatch, AWS::NoValue, !Ref GoogleGroupMatch]
+          SSOSYNC_USER_MATCH: !If [SetGoogleUserMatch, !Ref GoogleUserMatch, AWS::NoValue]
+          SSOSYNC_GROUP_MATCH: !If [SetGoogleGroupMatch, !Ref GoogleGroupMatch, AWS::NoValue]
           SSOSYNC_SYNC_METHOD: !Ref SyncMethod
-          SSOSYNC_IGNORE_GROUPS: !If [NoIgnoreGroups, AWS::NoValue, !Ref IgnoreGroups]
-          SSOSYNC_IGNORE_USERS: !If [NoIgnoreUsers, AWS::NoValue, !Ref IgnoreUsers]
-          SSOSYNC_INCLUDE_GROUPS: !If [NoIncludeGroups, AWS::NoValue, !Ref IncludeGroups]
+          SSOSYNC_IGNORE_GROUPS: !If [SetIgnoreGroups, !Ref IgnoreGroups, AWS::NoValue]
+          SSOSYNC_IGNORE_USERS: !If [SetIgnoreUsers, !Ref IgnoreUsers, AWS::NoValue]
+          SSOSYNC_INCLUDE_GROUPS: !If [SetIncludeGroups, !Ref IncludeGroups, AWS::NoValue]
       Policies:
         - Version: '2012-10-17'
           Statement:

--- a/template.yaml
+++ b/template.yaml
@@ -156,11 +156,11 @@ Parameters:
 Conditions:
   SetFunctionName: !Not [!Equals [!Ref "FunctionName", ""]]
   OnSchedule: !Not [!Equals [!Ref "ScheduleExpression", ""]]
-  SetGoogleUserMatch: !Not [!Equals [!Ref "GoogleUserMatch", ""]]
-  SetGoogleGroupMatch: !Not [!Equals [!Ref "GoogleGroupMatch", ""]]
+  SetGoogleUserMatch: !Or [!Not [!Equals [!Ref "GoogleUserMatch", ""]], !Equals [!Ref "SyncMethod", users_groups]]
+  SetGoogleGroupMatch: !Or [!Not [!Equals [!Ref "GoogleGroupMatch", ""]], !Equals [!Ref "SyncMethod", users_groups]]
   SetIgnoreGroups: !Not [!Equals [!Ref "IgnoreGroups", ""]]
   SetIgnoreUsers: !Not [!Equals [!Ref "IgnoreUsers", ""]]
-  SetIncludeGroups: !Or [!Equals [!Ref "SyncMethod", groups], !Equals [!Ref "IncludeGroups", ""]]
+  SetIncludeGroups: !Or [!Not [!Equals [!Ref "IncludeGroups", ""]], !Equals [!Ref "SyncMethod", groups]]
 
 Resources:
   SSOSyncFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -129,8 +129,10 @@ Resources:
   SSOSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: go1.x
-      Handler: dist/ssosync_linux_amd64_v1/ssosync
+      Runtime: provided.al2
+      Handler: bootstrap
+      Architectures:
+        - arm64
       Timeout: 300
       Environment:
         Variables:
@@ -185,6 +187,8 @@ Resources:
           Properties:
             Enabled: true
             Schedule: !Ref ScheduleExpression
+    Metadata:
+      BuildMethod: makefile
 
   AWSGoogleCredentialsSecret:
     Type: "AWS::SecretsManager::Secret"

--- a/template.yaml
+++ b/template.yaml
@@ -142,19 +142,13 @@ Parameters:
     AllowedValues:
       - groups
       - users_groups
-  TimeOut:
-    Type: Number
-    Description: Timeout for the Lambda function
-    Default: 300
-    MinValue: 1
-    MaxValue: 900
 
 Resources:
   SSOSyncFunction:
     Type: AWS::Serverless::Function
     Properties:
       Runtime: provided.al2
-      Handler: dist/ssosync_linux_arm64/ssosync
+      Handler: bootstrap
       Architectures:
         - arm64
       Timeout: !Ref TimeOut
@@ -175,7 +169,8 @@ Resources:
           SSOSYNC_IGNORE_USERS: !Ref IgnoreUsers
           SSOSYNC_INCLUDE_GROUPS: !Ref IncludeGroups
       Policies:
-        - Statement:
+        - Version: '2012-10-17'
+          Statement:
             - Sid: SSMGetParameterPolicy
               Effect: Allow
               Action:
@@ -187,8 +182,6 @@ Resources:
                 - !Ref AWSSCIMAccessTokenSecret
                 - !Ref AWSRegionSecret
                 - !Ref AWSIdentityStoreIDSecret
-        - Version: '2012-10-17'
-          Statement:
             - Sid: IdentityStoreAccesPolicy
               Effect: Allow
               Action:
@@ -217,8 +210,6 @@ Resources:
           Properties:
             Enabled: true
             Schedule: !Ref ScheduleExpression
-    Metadata:
-      BuildMethod: makefile
 
   AWSGoogleCredentialsSecret:
     Type: "AWS::SecretsManager::Secret"

--- a/test_local.sh
+++ b/test_local.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# This script is used to test the lambda function locally
+function log {
+    echo -e "\033[32m$1\033[0m"
+}
+
+# First build just the go code
+log "Building go code"
+make go-build
+
+# Rebuild the SAM application
+log "Building SAM application"
+sam build 
+
+# Invoke the lambda function
+log "Invoking lambda function (using env variables from .env, event from event.json)"
+touch .env
+touch event.json
+sam local invoke --env-vars .env -e event.json


### PR DESCRIPTION
Most changes are from the rebase, more configuration may be needed since it looks like some more providers are supported now, all changes pertaining to supporting setting the group to match on are in `cmd/root.go`. 